### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 		<version.assertj>3.2.0</version.assertj>
 		<version.mockito>1.10.19</version.mockito>
 		<version.commons-lang>2.6</version.commons-lang>
-		<version.commons-collections>3.2.1</version.commons-collections>
+		<version.commons-collections>3.2.2</version.commons-collections>
 		<version.commons-fileupload>1.3.1</version.commons-fileupload>
 		<version.commons-codec>1.6</version.commons-codec>
 


### PR DESCRIPTION

Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/